### PR TITLE
Fixing another typo for the maven dependency for the selenium-htmlunit-driver

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -167,8 +167,8 @@ Then ensure you have added the dependency:
 
 <!-- necessary only if you are using WebDriver -->
 <dependency>
-  <groupId>org.seleniumhq.selenium:selenium-htmlunit-driver/groupId>
-  <artifactId>org.seleniumhq.selenium</artifactId>
+  <groupId>org.seleniumhq.selenium</groupId>
+  <artifactId>selenium-htmlunit-driver</artifactId>
   <version>{selenium-version}</version>
   <scope>test</scope>
 </dependency>
@@ -214,15 +214,15 @@ Then ensure you have added the dependency:
 
 <!-- necessary only if you are using WebDriver -->
 <dependency>
-  <groupId>org.seleniumhq.selenium:selenium-htmlunit-driver</groupId>
-  <artifactId>org.seleniumhq.selenium</artifactId>
+  <groupId>org.seleniumhq.selenium</groupId>
+  <artifactId>selenium-htmlunit-driver</artifactId>
   <version>{selenium-version}</version>
   <scope>test</scope>
 </dependency>
 
 <!-- necessary only if you are using Geb -->
 <dependency>
-  <groupId>org.gebish/groupId>
+  <groupId>org.gebish</groupId>
   <artifactId>geb-spock</artifactId>
   <version>{geb-version}</version>
   <scope>test</scope>


### PR DESCRIPTION
Fixing another typo for the maven dependency for the selenium-htmlunit-driver.
