### PR TITLE
contextPath can be configured

### DIFF
--- a/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/matchers/UrlRegexRequestMatcher.java
+++ b/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/matchers/UrlRegexRequestMatcher.java
@@ -20,7 +20,9 @@ import com.gargoylesoftware.htmlunit.WebRequest;
 import java.util.regex.Pattern;
 
 /**
- * An implementation of WebRequestMatcher that allows matching on WebRequest#getUrl().toExternalForm() using a regular expression. For example, if you would like to match on the domain code.jquery.com, you might want to use the following:</p>
+ * <p>
+ * An implementation of WebRequestMatcher that allows matching on WebRequest#getUrl().toExternalForm() using a regular expression. For example, if you would like to match on the domain code.jquery.com, you might want to use the following:
+ * </p>
  *
  * <pre>
  * WebRequestMatcher cdnMatcher = new UrlRegexRequestMatcher(".*?//code.jquery.com/.*");

--- a/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriver.java
+++ b/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriver.java
@@ -63,7 +63,9 @@ import com.gargoylesoftware.htmlunit.WebConnection;
  *
  */
 public class MockMvcHtmlUnitDriver extends HtmlUnitDriver {
-	private WebClient webClient;
+
+    private WebClient webClient;
+    private String contextPath;
 
 	public MockMvcHtmlUnitDriver(WebApplicationContext webContext) {
 		setWebContext(webContext);
@@ -88,7 +90,13 @@ public class MockMvcHtmlUnitDriver extends HtmlUnitDriver {
 		setMockMvc(mockMvc);
 	}
 
-	public MockMvcHtmlUnitDriver(MockMvc mockMvc, boolean enableJavascript) {
+    public MockMvcHtmlUnitDriver(MockMvc mockMvc, String contextPath) {
+        super();
+        this.contextPath = contextPath;
+        setMockMvc(mockMvc);
+    }
+
+    public MockMvcHtmlUnitDriver(MockMvc mockMvc, boolean enableJavascript) {
 		super(enableJavascript);
 		setMockMvc(mockMvc);
 	}
@@ -129,6 +137,6 @@ public class MockMvcHtmlUnitDriver extends HtmlUnitDriver {
 
 	private void setMockMvc(MockMvc mockMvc) {
 		Assert.notNull(mockMvc, "mockMvc cannot be null");
-		webClient.setWebConnection(new MockMvcWebConnection(mockMvc));
+		webClient.setWebConnection(new MockMvcWebConnection(mockMvc, contextPath));
 	}
 }


### PR DESCRIPTION
Allows `contextPath` to be changed/configured.

Please note that I only added the constructor I needed. Maybe you should provide a builder for `MockMvcHtmlUnitDriver`to stop the telescoping constructor phenomen - I think 4 or 5 additional contructors will be needed to catch all cases.

fixes #40 