### PR TITLE
Implemented builder for adapted HtmlUnitDriver

### DIFF
--- a/mail-webapp/src/test/groovy/sample/geb/GebCreateMessagesSpec.groovy
+++ b/mail-webapp/src/test/groovy/sample/geb/GebCreateMessagesSpec.groovy
@@ -11,16 +11,13 @@
  * specific language governing permissions and limitations under the License.
  */
 package sample.geb
-
 import geb.spock.GebReportingSpec
-import org.junit.After
-import org.junit.Before
-import org.openqa.selenium.WebDriver
+import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriver
+import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import sample.config.MockDataConfig
@@ -28,7 +25,6 @@ import sample.config.WebMvcConfig
 import sample.data.Message
 import sample.geb.pages.CreateMessagePage
 import sample.geb.pages.ViewMessagePage
-
 /**
  *
  * @author Rob Winch
@@ -43,11 +39,12 @@ class GebCreateMessagesSpec extends GebReportingSpec {
 	@Autowired
 	Message expectedMessage;
 
-	WebDriver driver;
+	HtmlUnitDriver driver;
 
 	def setup() {
 		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
-		driver = new MockMvcHtmlUnitDriver(mockMvc, true);
+		driver = MockMvcHtmlUnitDriverBuilder.connectTo(mockMvc).build();
+		driver.setJavascriptEnabled(true);
 		browser.driver = driver
 	}
 

--- a/mail-webapp/src/test/java/sample/webdriver/MockMvcHtmlUnitDriverCreateMessageTests.java
+++ b/mail-webapp/src/test/java/sample/webdriver/MockMvcHtmlUnitDriverCreateMessageTests.java
@@ -5,12 +5,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriver;
+import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import sample.config.MockDataConfig;
@@ -31,7 +32,7 @@ import static sample.fest.Assertions.assertThat;
  * there is in how you would write the tests.</li>
  * <li>The only difference is how we initialize our {@link WebDriver}</li>
  * <li>We do not need to run the web application on a server for this test since we are using
- * {@link org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriver}</li>
+ * {@link org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder}</li>
  * </ul>
  *
  * @author Rob Winch
@@ -52,7 +53,13 @@ public class MockMvcHtmlUnitDriverCreateMessageTests {
 	@Before
 	public void setup() {
 		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
-		driver = new MockMvcHtmlUnitDriver(mockMvc, true);
+		driver = createDriver(mockMvc);
+	}
+
+	private static HtmlUnitDriver createDriver(final MockMvc mockMvc) {
+		final HtmlUnitDriver htmlUnitDriver = MockMvcHtmlUnitDriverBuilder.connectTo(mockMvc).build();
+		htmlUnitDriver.setJavascriptEnabled(true);
+		return htmlUnitDriver;
 	}
 
 	@After

--- a/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
+++ b/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
@@ -12,10 +12,10 @@
  */
 package org.springframework.test.web.servlet.htmlunit;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.gargoylesoftware.htmlunit.CookieManager;
+import com.gargoylesoftware.htmlunit.WebConnection;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.WebResponse;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,12 +24,10 @@ import org.springframework.test.web.servlet.htmlunit.geb.GebSpecTestExecutionLis
 import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriver;
 import org.springframework.util.Assert;
 
-import com.gargoylesoftware.htmlunit.CookieManager;
-import com.gargoylesoftware.htmlunit.WebConnection;
-import com.gargoylesoftware.htmlunit.WebRequest;
-import com.gargoylesoftware.htmlunit.WebResponse;
-
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * <p>
@@ -51,6 +49,7 @@ import javax.servlet.http.HttpServletRequest;
  *
  * @author Rob Winch
  * @see MockMvcHtmlUnitDriver
+ * @see org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder
  * @see GebSpecTestExecutionListener
  */
 public final class MockMvcWebConnection implements WebConnection {

--- a/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/geb/GebSpecTestExecutionListener.java
+++ b/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/geb/GebSpecTestExecutionListener.java
@@ -13,12 +13,13 @@
 package org.springframework.test.web.servlet.htmlunit.geb;
 
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
-import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriver;
+import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -26,8 +27,8 @@ import org.springframework.web.context.WebApplicationContext;
  * <strong>NOTE</strong> This is experimental and may be removed at any time.
  * </p>
  * <p>
- * A {@link TestExecutionListener} that is intended to automatically inject a {@link MockMvcHtmlUnitDriver} instance in
- * subclasses of GebSpec.
+ * A {@link TestExecutionListener} that is intended to automatically inject a special HtmlUnitDriver
+ * instance in subclasses of GebSpec.
  * </p>
  * <p>
  * To use it ensure that you have the Spock Spring integration jar on your classpath and then update your test to look
@@ -45,7 +46,7 @@ import org.springframework.web.context.WebApplicationContext;
  * </pre>
  *
  * @author Rob Winch
- *
+ * @see org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder
  */
 public class GebSpecTestExecutionListener extends AbstractTestExecutionListener {
 
@@ -56,7 +57,10 @@ public class GebSpecTestExecutionListener extends AbstractTestExecutionListener 
 		BeanWrapper testInstanceBeanWrapper = PropertyAccessorFactory.forBeanPropertyAccess(testInstance);
 		Capabilities capabilities = (Capabilities) testInstanceBeanWrapper
 				.getPropertyValue("browser.driver.capabilities");
-		MockMvcHtmlUnitDriver mockMvcHtmlUnitDriver = new MockMvcHtmlUnitDriver(context, capabilities);
+		HtmlUnitDriver mockMvcHtmlUnitDriver = MockMvcHtmlUnitDriverBuilder
+				.connectTo(context)
+				.with(capabilities)
+				.build();
 		testInstanceBeanWrapper.setPropertyValue("browser.driver", mockMvcHtmlUnitDriver);
 	}
 }

--- a/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/matchers/UrlRegexRequestMatcher.java
+++ b/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/matchers/UrlRegexRequestMatcher.java
@@ -20,7 +20,9 @@ import com.gargoylesoftware.htmlunit.WebRequest;
 import java.util.regex.Pattern;
 
 /**
- * An implementation of WebRequestMatcher that allows matching on WebRequest#getUrl().toExternalForm() using a regular expression. For example, if you would like to match on the domain code.jquery.com, you might want to use the following:</p>
+ * <p>
+ * An implementation of WebRequestMatcher that allows matching on WebRequest#getUrl().toExternalForm() using a regular expression. For example, if you would like to match on the domain code.jquery.com, you might want to use the following:
+ * </p>
  *
  * <pre>
  * WebRequestMatcher cdnMatcher = new UrlRegexRequestMatcher(".*?//code.jquery.com/.*");

--- a/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriver.java
+++ b/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriver.java
@@ -62,6 +62,7 @@ import com.gargoylesoftware.htmlunit.WebConnection;
  * @see MockMvcWebConnection
  *
  */
+@Deprecated
 public class MockMvcHtmlUnitDriver extends HtmlUnitDriver {
 	private WebClient webClient;
 

--- a/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriverBuilder.java
+++ b/spring-test-htmlunit/src/main/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriverBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.test.web.servlet.htmlunit.webdriver;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.htmlunit.MockMvcWebConnection;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.Assert;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * <p>
+ * Builder that simplifies creation of an adapted {@link }HtmlUnitDriver} that
+ * allows running tests off line by utilizing Spring's {@link MockMvc} to
+ * bridge between a request and a response. By doing this we are able to avoid
+ * making any HTTP calls when our tests are running. This implies we do not
+ * need to start a web container to run our tests.
+ * </p>
+ * <p>
+ * Example usage can be seen below:
+ * </p>
+ * <h2>Instantiate with WebApplicationContext</h2>
+ *
+ * <pre>
+ * WebApplicationContext context = ...
+ * HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.connectTo(context).build();
+ *
+ * ... use driver as you would a "normal" HtmlUnitDriver ...
+ * </pre>
+ *
+ * <h2>Instantiate with MockMvc</h2>
+ *
+ * <pre>
+ * MockMvc mockMvc = ...
+ * HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.connectTo(mockMvc).build();
+ *
+ * ... use driver as you would a "normal" HtmlUnitDriver ...
+ * </pre>
+ *
+ * <h2>Instantiate with your own MockMvcWebConnection</h2>
+ * <p>
+ * Sometimes it is useful to adapt the settings of the
+ * {@code MockMvcWebConnection} used. For example it can be necessary to tune
+ * the connection if you want to set the {@code contextPath} used. For example
+ * if you want to configure no context path at all you can use:
+ * </p>
+ *
+ * <pre>
+ * MockMvc mockMvc = ...
+ * MockMvcWebConnection connection = new MockMvcWebConnection(mockMvc, "");
+ * HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.via(connection).build();
+ *
+ * ... use driver as you would a "normal" HtmlUnitDriver ...
+ * </pre>
+
+ *
+ * @author Stefan Pennndorf
+ * @see MockMvc
+ * @see MockMvcWebConnection
+ *
+ */
+public final class MockMvcHtmlUnitDriverBuilder {
+
+    private final MockMvcWebConnection connection;
+
+    private final Capabilities capabilities;
+
+    private MockMvcHtmlUnitDriverBuilder(MockMvcWebConnection connection) {
+        this(connection, null);
+    }
+
+    private MockMvcHtmlUnitDriverBuilder(MockMvcWebConnection connection, Capabilities capabilities) {
+        Assert.notNull(connection, "connection cannot be null");
+        this.connection = connection;
+        this.capabilities = capabilities;
+    }
+
+    public static MockMvcHtmlUnitDriverBuilder connectTo(final MockMvc mockMvc) {
+        final MockMvcWebConnection webConnection = new MockMvcWebConnection(mockMvc);
+        return new MockMvcHtmlUnitDriverBuilder(webConnection);
+    }
+
+    public static MockMvcHtmlUnitDriverBuilder connectTo(final WebApplicationContext webContext) {
+        Assert.notNull(webContext, "webContext cannot be null");
+        final MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(webContext).build();
+        return connectTo(mockMvc);
+    }
+
+    public static MockMvcHtmlUnitDriverBuilder via(MockMvcWebConnection connection) {
+        return new MockMvcHtmlUnitDriverBuilder(connection);
+    }
+
+    public MockMvcHtmlUnitDriverBuilder with(Capabilities capabilities) {
+        return new MockMvcHtmlUnitDriverBuilder(connection, capabilities);
+    }
+
+    public HtmlUnitDriver build() {
+        class MockMvcHtmlUnitDriver extends HtmlUnitDriver {
+            private MockMvcHtmlUnitDriver() {
+                super();
+            }
+
+            private MockMvcHtmlUnitDriver(final Capabilities capabilities) {
+                super(capabilities);
+            }
+
+            @Override
+            protected WebClient modifyWebClient(WebClient client) {
+                client = super.modifyWebClient(client);
+                client.setWebConnection(connection);
+                return client;
+            }
+        }
+
+        return (capabilities == null)
+                ? new MockMvcHtmlUnitDriver()
+                : new MockMvcHtmlUnitDriver(capabilities);
+    }
+}

--- a/spring-test-htmlunit/src/test/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriverBuilderTest.java
+++ b/spring-test-htmlunit/src/test/java/org/springframework/test/web/servlet/htmlunit/webdriver/MockMvcHtmlUnitDriverBuilderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.test.web.servlet.htmlunit.webdriver;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.htmlunit.HelloController;
+import org.springframework.test.web.servlet.htmlunit.MockMvcWebConnection;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ *
+ * @author Stefan Penndorf
+ */
+public class MockMvcHtmlUnitDriverBuilderTest {
+
+    private MockMvc mockMvc;
+
+    private MockMvcWebConnection connection;
+
+    @Before
+    public void setup() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new HelloController())
+                .build();
+        connection = new MockMvcWebConnection(mockMvc);
+    }
+
+    @Test
+    public void canBuildDriverFromMockMvc() {
+        final HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.connectTo(mockMvc).build();
+
+        assertThat(driver).isNotNull();
+    }
+
+    @Test
+    public void canBuildViaMockMvcConnection() {
+        final HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.via(connection).build();
+
+        assertThat(driver).isNotNull();
+    }
+
+
+    @Test
+    public void usesMockMvcWebConnection() {
+        final HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.connectTo(mockMvc).build();
+
+        final WebClient webClient = (WebClient) ReflectionTestUtils.getField(driver, "webClient");
+        assertThat(webClient.getWebConnection()).isInstanceOf(MockMvcWebConnection.class);
+    }
+
+    @Test
+    public void usesIndividualMockMvcWebConnectionPassedToVia() {
+        final HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.via(connection).build();
+
+        final WebClient webClient = (WebClient) ReflectionTestUtils.getField(driver, "webClient");
+        assertThat(webClient.getWebConnection()).isSameAs(connection);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void requiresMockMvc() {
+        MockMvcHtmlUnitDriverBuilder.connectTo((MockMvc) null).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void requiresWebApplicationContext() {
+        MockMvcHtmlUnitDriverBuilder.connectTo((WebApplicationContext) null).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void requiresMockMvcWebConnection() {
+        MockMvcHtmlUnitDriverBuilder.via(null).build();
+    }
+
+}


### PR DESCRIPTION
fixes #40  - Implemented a builder for HtmlUnitDriver subclass (internal) that uses MockMvcWebConnection. Implemented builder method to allow direct definition of MockMvcWebConnection to use.

The context path can be defined with:

```
String contextPath = .....
MockMvc mockMvc = ....
MockMvcWebConnection con = new MockMvcWebConnection(mockMvc, contextPath);

HtmlUnitDriver driver = MockMvcHtmlUnitDriverBuilder.via(con).build();
```