### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ configure(rootProject) {
     options.author = true
     options.header = rootProject.description
     options.links(
-      'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
+      'https://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
     )
     source coreModuleProjects.collect { project ->
       project.sourceSets.main.allJava

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -35,7 +35,7 @@ def customizePom(pom, gradleProject) {
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector) result 301).